### PR TITLE
Build executables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+discord-simplerpc-linux
+discord-simplerpc-macos
+discord-simplerpc-windows

--- a/README.md
+++ b/README.md
@@ -8,19 +8,19 @@ This is a WIP and I am planning on making it easier use.
 ## Setup
 ### Required
 1. Create an application on the [Discord Developer Portal](https://discord.com/developers/applications) with whatever name you want "game" in your status to be. This is not a permanant choice; you can change it whenever you want.
-2. Download this repo, open `config.ini` with any text editor (Notepad++ for example), and edit `clientID` with the value of the client ID from the Discord Application created in step 1.
-3. Run the `install.bat` file.
+2. Download this repo, open `config.ini` with any text editor (Notepad++ for example), and edit `clientID` with the value of the client ID/application ID from the Discord Application created in step 1.
 
 ### Optional
-4. Go to the "rich presence art assets" tab and click "add images" to add 2 images for a big image and a small icon to use in the Game status.
+
+3. Go to the "rich presence art assets" tab and click "add images" to add 2 images for a big image and a small icon to use in the Game status.
 5. Add which ever of the OPTIONAL values in `config.ini` (`details, state, largeImageKey, smallImageKey, largeImageText, smallImageText, startTimestamp, endTimestamp`) or leave them blank and save.
 `largeImageKey` should be the name of the image you added in step 2 for the main status picture, while `smallImageKey` should be the name of the image you added for the smaller icon in the corner of the main picture.
 
 ## How to Use
-1. Run the `start.bat` file.
-2. The Playing status will stay as long as the terminal (the window that opens when this client is started) is open.
-3. You can edit any of the values in the config file at any time, and the status will automatically update after you save (5s delay to avoid timeout, but if your status goes away and you get a "RPC_CONNECTION_TIMEOUT" error, reload your Discord window and type "rs" into this client's terminal window).
-4. Shut down the client and get rid of your status by either pressing Ctrl+C while in the window or closing the terminal.
+1. Run the `discord-simplerpc` file.
+2. The Playing status will stay as long as the terminal (the window that opens when SimpleRPC is started) is open on the same computer with your running Discord Client.
+3. You can edit any of the values in the `config.ini` file at any time, and the status will update after you save the new config and restart SimpleRPC (shut down the client and open a new one)
+4. Shut down the client and get rid of your status by either pressing Ctrl+C while in the window or exiting like a normal window.
 
 ## Help/Contact
 Create an issue or contact me on Discord at `Al Kohollik#7268`

--- a/package.json
+++ b/package.json
@@ -3,12 +3,22 @@
   "version": "1.0.0",
   "description": "Simple rich presence client for a custom \"playing a game\" status",
   "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "nodemon index.js"
-  },
   "author": "Al-Kohollik",
   "license": "MIT",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "nodemon index.js",
+    "build": "npm run buildwin && npm run buildmac && npm run buildlinux",
+    "buildwin": "pkg index.js --config package.json --target node12-win --out-path ./discord-simplerpc-windows",
+    "buildmac": "pkg index.js --config package.json --target node12-macos --out-path ./discord-simplerpc-macos",
+    "buildlinux": "pkg index.js --config package.json --target node12-linux --out-path ./discord-simplerpc-linux"
+  },
+  "bin": "index.js",
+  "pkg": {
+    "assets": [
+      "node_modules/**/*"
+    ]
+  },
   "dependencies": {
     "discord-rich-presence": "0.0.8",
     "ini": "^1.3.6",


### PR DESCRIPTION
Set up pkg for this client to build executables for Windows, MacOS, Linux to let devices not need to have Node.js and dependencies installed.